### PR TITLE
removed extra space

### DIFF
--- a/dead_records.py
+++ b/dead_records.py
@@ -108,7 +108,7 @@ def CNAME_check(deadz):
             cnamez = str(d) + " --> " + check.decode() + "\n"
             write_cname.write(cnamez)
 
-        exist_check = pathlib.Path("cname-temp.txt")
+    exist_check = pathlib.Path("cname-temp.txt")
     if exist_check.exists() == True:
         pass
     else:


### PR DESCRIPTION
When running, the script was failing because of a extra space

```
Traceback (most recent call last):
  File "dead_records.py", line 160, in <module>
    main()
  File "dead_records.py", line 155, in main
    output()
  File "dead_records.py", line 130, in output
    CNAME_check(dead)
  File "dead_records.py", line 112, in CNAME_check
    if exist_check.exists() == True:
UnboundLocalError: local variable 'exist_check' referenced before assignment
```